### PR TITLE
Fixed bug in report template "A.5 Risikoanalyse"

### DIFF
--- a/sernet.gs.server/WebContent/WEB-INF/reportDeposit/bp-A5-riskanalysis.rptdesign
+++ b/sernet.gs.server/WebContent/WEB-INF/reportDeposit/bp-A5-riskanalysis.rptdesign
@@ -8703,7 +8703,7 @@
                                         <structure>
                                             <property name="name">itverbund_normal_wirkung</property>
                                             <text-property name="displayName">itverbund_normal_wirkung</text-property>
-                                            <expression name="expression" type="javascript">dataSetRow["Schutzbedarfskategorie__unkritisch__-__Innen-____Außenwirkung__(Informationsverbund)"]</expression>
+                                            <expression name="expression" type="javascript">dataSetRow["Schutzbedarfskategorie__Normal__-__Innen-____Außenwirkung__(Informationsverbund)"]</expression>
                                             <property name="dataType">string</property>
                                         </structure>
                                     </list-property>


### PR DESCRIPTION
Hi,

uns ist letztens beim generieren unserer Reports aufgefallen, dass an mindestens einer Stelle eurer Report-Templates die Datenquelle nicht stimmt.

Im Report A.5 Risikoanalyse wird unter der _Definition der Schutzbedarfskategorien_ in der Tabelle _Stufe: Normal_ in der Zeile _Innen-/Außenwirkung_ der Content aus _Stufe: Unkritisch_ angezeigt, da unter dem Property Name `itverbund_normal` trotzdem noch die Expression aus der Tabelle Unkritisch verwendet wird. Dies wird mit diesem PR gefixt.

Nik

---

Hi,

we recently noticed a bug when generating our reports, at at least one place the data source for a specific cell in a table isn't pointing to the right place and is displaying wrong data when the report is generated.

In the report A.5 Risikoanalyse the expression in _Definition der Schutzbedarfskategorien_ in the table _Stufe: Normal_  for the line _Innen-/Außenwirkung_ is requesting data for the same property in the table _Stufe: Unkritisch_, which results in the wrong data being displayed in the report when having custom texts set for these protection requirement categories. This PR fixes this small issue.

Nik