### PR TITLE
Update target-platform.target

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -114,13 +114,13 @@
 <unit id="org.eclipse.babel.nls_eclipse_cs.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.babel.nls_eclipse_de.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.babel.nls_eclipse_it.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/technology/babel/update-site/R0.18.2/2020-06/"/>
+<repository location="http://archive.eclipse.org/technology/babel/update-site/R0.18.2/2020-06/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.babel.nls_datatools_cs.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.babel.nls_datatools_de.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.babel.nls_datatools_it.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/"/>
+<repository location="http://archive.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/"/>
 </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/nebula/releases/2.4.2/"/>


### PR DESCRIPTION
Both references for the babel update site seems to be moved from the downloads sub-domain to the archive one.