### PR TITLE
Increase height of description fields for implementation of requirements/safeguards

### DIFF
--- a/sernet.gs.server/WebContent/WEB-INF/SNCA.xml
+++ b/sernet.gs.server/WebContent/WEB-INF/SNCA.xml
@@ -2912,7 +2912,8 @@ festgelegt. Die Ergebnisse werden anschließend zentral zusammengefasst und kons
                 name="Erläuterung"
                 required="false"
                 inputtype="text"
-                focus="true" />
+                focus="true"
+                textrows="10" />
             <huiproperty
                 id="mnums_umsetzung"
                 name="Umsetzung"
@@ -14019,7 +14020,7 @@ Wurden bereits weitere Stellen informiert?
                 <option id="bp_requirement_implementation_status_na" name="Not Applicable" />
             </huiproperty>
             <huiproperty id="bp_requirement_implementation_desc" name="Description"
-                required="false" inputtype="text" focus="true" />
+                required="false" inputtype="text" focus="true" textrows="10" />
             <huiproperty id="bp_requirement_implementation_by_date" name="Implementation by"
                 required="false" inputtype="date">
                 <defaultRule class="Today" />

--- a/sernet.gs.server/testSrc/SNCA.xml
+++ b/sernet.gs.server/testSrc/SNCA.xml
@@ -2912,7 +2912,8 @@ festgelegt. Die Ergebnisse werden anschließend zentral zusammengefasst und kons
                 name="Erläuterung"
                 required="false"
                 inputtype="text"
-                focus="true" />
+                focus="true"
+                textrows="10" />
             <huiproperty
                 id="mnums_umsetzung"
                 name="Umsetzung"
@@ -14019,7 +14020,7 @@ Wurden bereits weitere Stellen informiert?
                 <option id="bp_requirement_implementation_status_na" name="Not Applicable" />
             </huiproperty>
             <huiproperty id="bp_requirement_implementation_desc" name="Description"
-                required="false" inputtype="text" focus="true" />
+                required="false" inputtype="text" focus="true" textrows="10" />
             <huiproperty id="bp_requirement_implementation_by_date" name="Implementation by"
                 required="false" inputtype="date">
                 <defaultRule class="Today" />


### PR DESCRIPTION
When doing an IT-Grundschutz Check/Basic Security Check, it is crucial to properly document the implementation status of the requirements/safeguards beyond a simple "yes"/"partially"/"no"/"unnecessary".
Right now, that particular field is rather small in Verinice, which makes it hard to use the description field.  
With this PR, this field (both in the 100-x and 200-x views) is increased to 10 lines (instead of the default of 4), similar to the text fields for audits.
It may be worth considering to make this field even larger, but that would be inconsistent to other text fields and it might become too large in some cases.